### PR TITLE
Made the rotation camera relative, more intutive

### DIFF
--- a/Assets/Scenes/cube_test.unity
+++ b/Assets/Scenes/cube_test.unity
@@ -137,6 +137,7 @@ GameObject:
   - component: {fileID: 334989763}
   - component: {fileID: 334989764}
   - component: {fileID: 334989765}
+  - component: {fileID: 334989766}
   m_Layer: 0
   m_Name: Cube
   m_TagString: Untagged
@@ -193,7 +194,7 @@ MeshFilter:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 334989758}
-  m_Mesh: {fileID: -5495902117074765545, guid: f2dade21738a9dd409dd17d707c05366, type: 3}
+  m_Mesh: {fileID: -5495902117074765545, guid: 5e961d300b4698345b72a1314f28754a, type: 3}
 --- !u!4 &334989762
 Transform:
   m_ObjectHideFlags: 0
@@ -218,7 +219,7 @@ Rigidbody:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 334989758}
   serializedVersion: 4
-  m_Mass: 0.0000001
+  m_Mass: 100000
   m_Drag: 0
   m_AngularDrag: 0.05
   m_CenterOfMass: {x: 0, y: 0, z: 0}
@@ -270,7 +271,21 @@ MeshCollider:
   serializedVersion: 5
   m_Convex: 0
   m_CookingOptions: 30
-  m_Mesh: {fileID: -5495902117074765545, guid: f2dade21738a9dd409dd17d707c05366, type: 3}
+  m_Mesh: {fileID: -5495902117074765545, guid: 5e961d300b4698345b72a1314f28754a, type: 3}
+--- !u!114 &334989766
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 334989758}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a8bbbc6ab83ebb5aba9ec4e53556b08c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  rotationSpeed: 1
+  rotationAnchor: {fileID: 0}
 --- !u!1 &672582806
 GameObject:
   m_ObjectHideFlags: 0
@@ -417,7 +432,7 @@ Rigidbody:
   m_ImplicitCom: 1
   m_ImplicitTensor: 1
   m_UseGravity: 0
-  m_IsKinematic: 0
+  m_IsKinematic: 1
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
@@ -526,6 +541,7 @@ GameObject:
   - component: {fileID: 1578590932}
   - component: {fileID: 1578590931}
   - component: {fileID: 1578590930}
+  - component: {fileID: 1578590933}
   m_Layer: 6
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -607,6 +623,20 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 40.457, y: 45, z: 0}
+--- !u!114 &1578590933
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1578590929}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a70df04f4ce1a39a9804e92c6e132b7c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  rotationSpeed: 10
+  rotationAnchor: {fileID: 0}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/GyroscopeController.cs
+++ b/Assets/Scripts/GyroscopeController.cs
@@ -15,12 +15,14 @@ public class GyroscopeController : MonoBehaviour
     private Quaternion initialRotation;
     private Quaternion initialGyroRotation;
 
+    private Quaternion targetRotation;
 
     void Start()
     {
         Input.gyro.enabled = true;
         initialRotation = transform.rotation;
         initialGyroRotation = GyroToUnity(Input.gyro.attitude);
+        Input.gyro.updateInterval = 0.001f;
     }
 
 
@@ -51,7 +53,10 @@ public class GyroscopeController : MonoBehaviour
 
         // make it camera relative
         gyroAttitude = Camera.main.transform.rotation * gyroAttitude;
-        transform.rotation = gyroAttitude * Quaternion.Inverse(Camera.main.transform.rotation);
+        gyroAttitude = gyroAttitude * Quaternion.Inverse(Camera.main.transform.rotation);
+        targetRotation = gyroAttitude;
+        transform.rotation = Quaternion.Slerp(transform.rotation, targetRotation, Time.deltaTime * rotationSpeed);
+
     }
 
     private static Quaternion GyroToUnity(Quaternion q)

--- a/Assets/Scripts/GyroscopeController.cs
+++ b/Assets/Scripts/GyroscopeController.cs
@@ -12,11 +12,17 @@ public class GyroscopeController : MonoBehaviour
     private float lastTapTime = 0;
     private int lastTapFingerId = -1;
 
+    private Quaternion initialRotation;
+    private Quaternion initialGyroRotation;
+
+
     void Start()
     {
-        // Activate the gyroscope
         Input.gyro.enabled = true;
+        initialRotation = transform.rotation;
+        initialGyroRotation = GyroToUnity(Input.gyro.attitude);
     }
+
 
     void Update()
     {
@@ -25,7 +31,7 @@ public class GyroscopeController : MonoBehaviour
         {
             Touch touch = Input.GetTouch(0);
 
-            if (touch.phase == TouchPhase.Began) 
+            if (touch.phase == TouchPhase.Began)
             {
                 if (IsDoubleTap(touch.fingerId))
                 {
@@ -39,12 +45,18 @@ public class GyroscopeController : MonoBehaviour
             return;
         }
 
-        // Read data for gyroscope
-        Vector3 gyroRotationRate = Input.gyro.rotationRate;
-        // Vector3 gyroAcceleration = Input.gyro.userAcceleration;
+        // Read data from gyroscope
+        Quaternion gyroAttitude = Input.gyro.attitude;
+        gyroAttitude = initialRotation * Quaternion.Inverse(initialGyroRotation) * GyroToUnity(gyroAttitude);
 
-        // Example of a rotation
-        transform.Rotate(-gyroRotationRate.x, -gyroRotationRate.z, -gyroRotationRate.y);
+        // make it camera relative
+        gyroAttitude = Camera.main.transform.rotation * gyroAttitude;
+        transform.rotation = gyroAttitude * Quaternion.Inverse(Camera.main.transform.rotation);
+    }
+
+    private static Quaternion GyroToUnity(Quaternion q)
+    {
+        return new Quaternion(q.x, q.z, q.y, -q.w);
     }
 
     private bool IsDoubleTap(int fingerId)


### PR DESCRIPTION
This PR attempts to improve the cube controller, by making the rotation camera relative.
It uses gyro.input.attitude instead of the rotationRate used previously. This should make the rotation feel more consistent.
