### PR TITLE
Improved way of removing networkmanager duplicate

### DIFF
--- a/Assets/Scripts/Networking/ServerSceneManager.cs
+++ b/Assets/Scripts/Networking/ServerSceneManager.cs
@@ -6,23 +6,25 @@ using UnityEngine.SceneManagement;
 
 public class ServerSceneManager : MonoBehaviour
 {
-
     NetworkManager networkManager;
 
 
-    private IEnumerator Start()
+    void Awake()
     {
-        // wait for the network manager to be initialized
-        while (NetworkManager.Singleton == null)
-            yield return null;
-
         // prevent duplicates
-        if (GetComponent<NetworkManager>() != NetworkManager.Singleton)
+        if (FindObjectsOfType<ServerSceneManager>().Length > 1)
         {
             Debug.Log("Destroying this clone", gameObject);
-            Destroy(gameObject, 5f);
+            Destroy(gameObject);
         }
+        else
+        {
+            DontDestroyOnLoad(gameObject);
+        }
+    }
 
+    void Start()
+    {
         networkManager = GetComponent<NetworkManager>();
     }
 


### PR DESCRIPTION
This fixes an error with the network manager when the client disconnects.
Disconnecting and reconnecting should be smoother and no errors should occur. 