### PR TITLE
[Grass] reduce shadow bottleneck + switch off lighting

### DIFF
--- a/Assets/Materials/CubeGround/GrassCube.mat
+++ b/Assets/Materials/CubeGround/GrassCube.mat
@@ -108,6 +108,7 @@ Material:
     - _BumpScale: 1
     - _ClearCoatMask: 0
     - _ClearCoatSmoothness: 0
+    - _ComputeLighting: 0
     - _Cull: 2
     - _Cutoff: 0.5
     - _DetailAlbedoMapScale: 1
@@ -126,6 +127,8 @@ Material:
     - _Parallax: 0.005
     - _QueueOffset: 0
     - _ReceiveShadows: 1
+    - _ShadowIntensity: 1
+    - _ShadowTessellation: 0.6
     - _Smoothness: 0.5
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1


### PR DESCRIPTION
This PR introduces new parameters to tweak the grass lighting and shadows both in terms of visual and performance. The default values deactivate the computation of blade's normals and reduce almost by half the amount of grass blades generated during shadow passes. This way we get 60 FPS (at least on my laptop).

- Slider to reduce grass density in shadow passes (0.6f by default)
![Unity_i1MkPrNDkB](https://github.com/davidasberg/cubes_traveller/assets/86228445/359a7dd4-28ee-438b-bc8c-62c8a916fab2)

- Slider to soften shadow intensity (1.f by default)
![Unity_mQwTzaevFQ](https://github.com/davidasberg/cubes_traveller/assets/86228445/2e890a88-a21f-4a50-a736-499f645b2c75)

- Switch on / off the computation of normals to get correct lighting (off by default)
![Unity_cMi0wH7AA0](https://github.com/davidasberg/cubes_traveller/assets/86228445/73b6cb52-c3d7-4d9e-b3fd-d168218ae5c3)
